### PR TITLE
W01_PHJ

### DIFF
--- a/PHJu/Add4b.v
+++ b/PHJu/Add4b.v
@@ -1,0 +1,10 @@
+module Add4b(i_A, i_B, o_S, o_C);
+input [3:0] i_A, i_B;
+output wire [3:0] o_S;
+output wire o_C;
+wire [2:0] cout;
+FA FA0(i_A[0], i_B[0], 1'b0, o_S[0], cout[0]);
+FA FA1(i_A[1], i_B[1], cout[0], o_S[1], cout[1]);
+FA FA2(i_A[2], i_B[2], cout[1], o_S[2], cout[2]);
+FA FA3(i_A[3], i_B[3], cout[2], o_S[3], o_C);
+endmodule

--- a/PHJu/FA.v
+++ b/PHJu/FA.v
@@ -1,0 +1,10 @@
+module FA(i_A, i_B, i_C, o_S, o_C);
+input i_A, i_B, i_C;
+output o_S, o_C;
+wire HA0_o_S, HA0_o_C;
+wire HA1_o_S, HA1_o_C;
+HA HA0(i_A, i_B, HA0_o_S, HA0_o_C);
+HA HA1(HA0_o_S, i_C, HA1_o_S, HA1_o_C);
+assign o_S = HA1_o_S;
+assign o_C = HA0_o_C | HA1_o_C;
+endmodule

--- a/PHJu/HA.v
+++ b/PHJu/HA.v
@@ -1,0 +1,7 @@
+module HA(i_A, i_B, o_S, o_C);
+input i_A, i_B;
+output o_S;
+output o_C;
+assign o_S = i_A ^ i_B;
+assign o_C = i_A & i_B;
+endmodule

--- a/PHJu/tb_Add4b.v
+++ b/PHJu/tb_Add4b.v
@@ -1,0 +1,14 @@
+module tb_Add4b;
+reg [3:0] Add_i_A;
+reg [3:0] Add_i_B;
+reg Add_i_C;
+wire [3:0] Add_o_S;
+wire Add_o_C;
+Add4b U0(Add_i_A, Add_i_B, Add_o_S, Add_o_C);
+initial begin
+Add_i_C = 0;
+Add_i_A = 4'b1010; Add_i_B = 4'b1100;
+#10 Add_i_A = 5; Add_i_B = 7;
+#10 Add_i_A = 9; Add_i_B = 8;
+end
+endmodule


### PR DESCRIPTION
![스크린샷 2024-10-01 001734](https://github.com/user-attachments/assets/225e17c8-cec7-490e-a095-cc385df9a4c1)

파일마다 돌아가는 과정을 이해한대로 설명하고자 한다

- HA 코드
>  i_A와 i_B로 값을 받아오고 o_S는 A와 B의 합, o_C는 자리바꿈

- FA 코드
> HA 코드와 똑같이 값을 받아오고 합과 자리바꿈이 있음
> 차이점은 HA0, HA1 2개 존재
    -HA0에서는 A와 B의 값을 더해서 합과 자리바꿈을 구함
    -HA1에서는 HA0의 합과 i_C의 값을 더해 합과 자리바꿈을 구함
o_S는 HA1의 합
o_C는 두 가산기의 자리바꿈을 or처리하여 값을 넣음

- Add4b 코드는 비트를 사용

> 4비트의 i_A, i_B의 값을 입력받음
>  4비트의 입력값의 합을 저장하는 o_S이고 o_C는 최종값..?
3비트의 cout은 값을 저장
각각 A와 B를 더하고 S에 저장 cout에는 자리올림을 저장하고 그 뒤의 계산에 사용
    -총 4번 반복하여 o_C에 최종값이 들어감

- tb_Add4b 

> 4비트 크기의 A와 B 입력 레지스터와 i_C의 자리 올림 레지스터
> 4비트 크기의 합을 저장하는 S와 자리올림 C 와이어
> U0
    -A와 B의 합을 구해 o_S, o_C 출력

> 가산기..?
    -i_C의 값 0 고정, A는 4비트의 2진수(1010) 10, B는 4비트의 2진수 
     (1100) 12
    -A(10) + B(12) 수행
        --o_S는 4b'0110, o_C는 1
    -A(5) + B(7) 수행
        --o_S는 4b'1100, o_C는 0
    -A(9) + B(8) 수행
        --o_S는 4b'0001, o_C는 1

- 사진에 있는 파장과 비교해본다면 A와 B의 값을 더헤 S에 나타내고 C에는 자리올림을 나타내고 있다